### PR TITLE
extend `csv-table` directive with filter logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+bin/
 env/
 build/
 develop-eggs/
@@ -20,6 +21,9 @@ lib64/
 parts/
 sdist/
 var/
+dist/
+build/
+out/
 *.egg-info/
 .installed.cfg
 *.egg

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# sphinx_advanced_csv
-Sphinx plugin that extends csv-table directive of reStructuredText

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,47 @@
+Spinx CSV Filter
+=====================
+
+This is a sphinx plugin that extends ``csv-table`` directive of the
+``docutils`` text-processing system. It appends additional filter options 
+which exclude rows of a given CSV table.
+
+Features
+--------
+
+-  [x] Filters rows of a referenced CSV table that contains a regex pattern 
+   at a given column index.
+
+Installation
+------------
+
+To include the extension add the following line to the ``config.py`` in
+your Sphinx-Project.
+
+::
+
+    extensions = ['crate.sphinx.csv']
+
+If you have other extensions use:
+
+::
+
+    extensions.append('crate.sphinx.csv')
+
+First Example
+-------------
+
+This example excludes all rows if the value of column ``Attend?`` (Idx: 3)
+matches the regex pattern.
+
+::
+
+    .. csv-table:: Example Table
+       :header: Company,Contact,Country,Attend?
+       :file: example.csv
+       :exclude: {3: '(?i)Y\w*'}
+
+Options
+~~~~~~~
+
+-  ``:exclude:``: Python dictionary that defines on which **column indizes** 
+   the **regex pattern** are applied.

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,0 +1,210 @@
+##############################################################################
+#
+# Copyright (c) 2006 Zope Foundation and Contributors.
+# All Rights Reserved.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+"""Bootstrap a buildout-based project
+
+Simply run this script in a directory containing a buildout.cfg.
+The script accepts buildout command-line options, so you can
+use the -c option to specify an alternate configuration file.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+
+from optparse import OptionParser
+
+__version__ = '2015-07-01'
+# See zc.buildout's changelog if this version is up to date.
+
+tmpeggs = tempfile.mkdtemp(prefix='bootstrap-')
+
+usage = '''\
+[DESIRED PYTHON FOR BUILDOUT] bootstrap.py [options]
+
+Bootstraps a buildout-based project.
+
+Simply run this script in a directory containing a buildout.cfg, using the
+Python that you want bin/buildout to use.
+
+Note that by using --find-links to point to local resources, you can keep
+this script from going over the network.
+'''
+
+parser = OptionParser(usage=usage)
+parser.add_option("--version",
+                  action="store_true", default=False,
+                  help=("Return bootstrap.py version."))
+parser.add_option("-t", "--accept-buildout-test-releases",
+                  dest='accept_buildout_test_releases',
+                  action="store_true", default=False,
+                  help=("Normally, if you do not specify a --buildout-version, "
+                        "the bootstrap script and buildout gets the newest "
+                        "*final* versions of zc.buildout and its recipes and "
+                        "extensions for you.  If you use this flag, "
+                        "bootstrap and buildout will get the newest releases "
+                        "even if they are alphas or betas."))
+parser.add_option("-c", "--config-file",
+                  help=("Specify the path to the buildout configuration "
+                        "file to be used."))
+parser.add_option("-f", "--find-links",
+                  help=("Specify a URL to search for buildout releases"))
+parser.add_option("--allow-site-packages",
+                  action="store_true", default=False,
+                  help=("Let bootstrap.py use existing site packages"))
+parser.add_option("--buildout-version",
+                  help="Use a specific zc.buildout version")
+parser.add_option("--setuptools-version",
+                  help="Use a specific setuptools version")
+parser.add_option("--setuptools-to-dir",
+                  help=("Allow for re-use of existing directory of "
+                        "setuptools versions"))
+
+options, args = parser.parse_args()
+if options.version:
+    print("bootstrap.py version %s" % __version__)
+    sys.exit(0)
+
+
+######################################################################
+# load/install setuptools
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+ez = {}
+if os.path.exists('ez_setup.py'):
+    exec(open('ez_setup.py').read(), ez)
+else:
+    exec(urlopen('https://bootstrap.pypa.io/ez_setup.py').read(), ez)
+
+if not options.allow_site_packages:
+    # ez_setup imports site, which adds site packages
+    # this will remove them from the path to ensure that incompatible versions
+    # of setuptools are not in the path
+    import site
+    # inside a virtualenv, there is no 'getsitepackages'.
+    # We can't remove these reliably
+    if hasattr(site, 'getsitepackages'):
+        for sitepackage_path in site.getsitepackages():
+            # Strip all site-packages directories from sys.path that
+            # are not sys.prefix; this is because on Windows
+            # sys.prefix is a site-package directory.
+            if sitepackage_path != sys.prefix:
+                sys.path[:] = [x for x in sys.path
+                               if sitepackage_path not in x]
+
+setup_args = dict(to_dir=tmpeggs, download_delay=0)
+
+if options.setuptools_version is not None:
+    setup_args['version'] = options.setuptools_version
+if options.setuptools_to_dir is not None:
+    setup_args['to_dir'] = options.setuptools_to_dir
+
+ez['use_setuptools'](**setup_args)
+import setuptools
+import pkg_resources
+
+# This does not (always?) update the default working set.  We will
+# do it.
+for path in sys.path:
+    if path not in pkg_resources.working_set.entries:
+        pkg_resources.working_set.add_entry(path)
+
+######################################################################
+# Install buildout
+
+ws = pkg_resources.working_set
+
+setuptools_path = ws.find(
+    pkg_resources.Requirement.parse('setuptools')).location
+
+# Fix sys.path here as easy_install.pth added before PYTHONPATH
+cmd = [sys.executable, '-c',
+       'import sys; sys.path[0:0] = [%r]; ' % setuptools_path +
+       'from setuptools.command.easy_install import main; main()',
+       '-mZqNxd', tmpeggs]
+
+find_links = os.environ.get(
+    'bootstrap-testing-find-links',
+    options.find_links or
+    ('http://downloads.buildout.org/'
+     if options.accept_buildout_test_releases else None)
+    )
+if find_links:
+    cmd.extend(['-f', find_links])
+
+requirement = 'zc.buildout'
+version = options.buildout_version
+if version is None and not options.accept_buildout_test_releases:
+    # Figure out the most recent final version of zc.buildout.
+    import setuptools.package_index
+    _final_parts = '*final-', '*final'
+
+    def _final_version(parsed_version):
+        try:
+            return not parsed_version.is_prerelease
+        except AttributeError:
+            # Older setuptools
+            for part in parsed_version:
+                if (part[:1] == '*') and (part not in _final_parts):
+                    return False
+            return True
+
+    index = setuptools.package_index.PackageIndex(
+        search_path=[setuptools_path])
+    if find_links:
+        index.add_find_links((find_links,))
+    req = pkg_resources.Requirement.parse(requirement)
+    if index.obtain(req) is not None:
+        best = []
+        bestv = None
+        for dist in index[req.project_name]:
+            distv = dist.parsed_version
+            if _final_version(distv):
+                if bestv is None or distv > bestv:
+                    best = [dist]
+                    bestv = distv
+                elif distv == bestv:
+                    best.append(dist)
+        if best:
+            best.sort()
+            version = best[-1].version
+if version:
+    requirement = '=='.join((requirement, version))
+cmd.append(requirement)
+
+import subprocess
+if subprocess.call(cmd) != 0:
+    raise Exception(
+        "Failed to execute command:\n%s" % repr(cmd)[1:-1])
+
+######################################################################
+# Import and run buildout
+
+ws.add_entry(tmpeggs)
+ws.require(requirement)
+import zc.buildout.buildout
+
+if not [a for a in args if '=' not in a]:
+    args.append('bootstrap')
+
+# if -c was provided, we push it back into args for buildout' main function
+if options.config_file is not None:
+    args[0:0] = ['-c', options.config_file]
+
+zc.buildout.buildout.main(args)
+shutil.rmtree(tmpeggs)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,14 @@
+[buildout]
+extends = versions.cfg
+parts = sphinx
+versions = versions
+show-picked-versions = true
+
+[sphinx]
+recipe = zc.recipe.egg:script
+eggs = sphinx
+relative-paths=true
+scripts = sphinx-build=sphinx
+initialization =
+    sys.argv.extend(['-N', '-q', '-b', 'html',
+                     '-E', 'docs', '${buildout:directory}/out/html'])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,11 @@
+import sys, os
+
+sys.path.append(os.path.abspath('../src'))
+
+# The suffix of source filenames.
+source_suffix = '.txt'
+
+# The master toctree document.
+master_doc = 'index'
+exclude_trees = ['pyenv', 'tmp', 'out', 'parts', 'clients', 'eggs']
+extensions = ['crate.sphinx.csv']

--- a/docs/example.csv
+++ b/docs/example.csv
@@ -1,0 +1,3 @@
+Centro comercial Moctezuma	Francisco Chang	Mexico	YES
+Alfreds Futterkiste	Maria Anders	Germany	y
+Ernst Handel	Roland Mendel	Austria	NO

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -1,0 +1,12 @@
+=============
+Example Table
+=============
+
+This example excludes all rows if the value of column ``Attend?`` (Idx: 3)
+matches the regex pattern.
+
+.. csv-table:: Example Table
+   :header: Company,Contact,Country,Attend?
+   :delim: U+0009
+   :file: example.csv
+   :exclude: {3: '(?i)Y\w*'}

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+import os
+from setuptools import setup, find_packages
+
+def read(path):
+    with open(os.path.join(os.path.dirname(__file__), path)) as f:
+        return f.read()
+
+setup(
+    name='sphinx_csv_filter',
+    version='0.1.0',
+    url='https://github.com/crate/sphinx_csv_filter',
+    author='CRATE Technology GmbH',
+    author_email='office@crate.io',
+    package_dir={'': 'src'},
+    description='Sphinx CSV filter extension for Crate Documentation',
+    long_description=read('README.rst'),
+    platforms=['any'],
+    license='Apache License 2.0',
+    keywords='crate sphinx csv',
+    packages=find_packages('src'),
+    namespace_packages=['crate'],
+    entry_points=dict(),
+    extras_require=dict(),
+    install_requires=[],
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Topic :: Database'
+    ],
+)

--- a/src/crate/__init__.py
+++ b/src/crate/__init__.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+# this is a namespace package
+try:
+    import pkg_resources
+
+
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+
+
+    __path__ = pkgutil.extend_path(__path__, __name__)

--- a/src/crate/sphinx/csv.py
+++ b/src/crate/sphinx/csv.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8; -*-
+
+import csv
+import ast
+import re
+
+from docutils.parsers.rst.directives.tables import CSVTable
+from docutils.utils import SystemMessagePropagation
+from docutils import statemachine
+from docutils.parsers.rst import directives
+
+class CSVFilterDirective(CSVTable):
+    """ The CSV Filter directive renders csv defined in config
+        and filter rows that contains a specified string
+    """
+
+    CSVTable.option_spec['exclude'] = directives.unchanged
+
+    def parse_csv_data_into_rows(self, csv_data, dialect, source):
+        rows, max_cols = super().parse_csv_data_into_rows(csv_data, dialect, source)
+        if 'exclude' in self.options:
+            exclude_dict = ast.literal_eval(self.options['exclude'])
+            rows = self._apply_filter(rows, exclude_dict)
+        return rows, max_cols
+
+    def _apply_filter(self, rows, exclude_dict):
+        result = []
+
+        # append row that does not contain filter at column index
+        for row in rows:
+            exclude = False
+            for col_idx, pattern in exclude_dict.items():
+                # cell data value is located at hardcoded index pos. 3
+                # data type is always a string literal
+                try:
+                    val = row[col_idx][3][0]
+                    if re.match(pattern, val):
+                        exclude = True
+                        break
+                except IndexError:
+                    error = self.state_machine.reporter.error(
+                        'Insufficient data supplied. Number of defined headers do not match ' 
+                        'the number of columns in the table data')
+                    raise SystemMessagePropagation(error)
+                
+            if not exclude:
+                result.append(row)
+
+        return result
+
+def setup(sphinx):
+    sphinx.add_directive('csv-table', CSVFilterDirective)

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,0 +1,19 @@
+[versions]
+Sphinx = 1.4.5
+Babel = 2.2.0
+Jinja2 = 2.8
+Pygments = 2.1.3
+alabaster = 0.7.7
+docutils = 0.12
+pytz = 2016.1
+six = 1.10.0
+snowballstemmer = 1.2.1
+zc.recipe.egg = 2.0.3
+
+# Required by:
+# Jinja2==2.8
+MarkupSafe = 0.23
+
+# Required by:
+# Sphinx==1.4.5
+imagesize = 0.7.0


### PR DESCRIPTION
this plugin extends the `csv-table` directive from `docutils` package
with additional filter options.