### PR TITLE
renamed directive from csv-table to csv-filter

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,3 +4,6 @@ CHANGES
 
 Unreleased
 ==========
+
+- BREAKING: Renamed directive from ``csv-table`` to ``csv-filter`` in
+  order not to override exisint ``csv-table`` directive.

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -13,8 +13,9 @@ eggs = wheel
 [sphinx]
 recipe = zc.recipe.egg:script
 eggs = sphinx
+extra-paths = ${buildout:directory}/src
 relative-paths=true
 scripts = sphinx-build=sphinx
 initialization =
-    sys.argv.extend(['-N', '-q', '-b', 'html',
+    sys.argv.extend(['-n', '-W', '-b', 'html',
                      '-E', 'docs', '${buildout:directory}/out/html'])

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,3 @@
-import sys, os
-
-sys.path.append(os.path.abspath('../src'))
-
 # The suffix of source filenames.
 source_suffix = '.txt'
 

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -5,7 +5,7 @@ Example Table
 This example excludes all rows if the value of column ``Attend?`` (Idx: 3)
 matches the regex pattern.
 
-.. csv-table:: Example Table
+.. csv-filter:: Example Table
    :header: Company,Contact,Country,Attend?
    :delim: U+0009
    :file: example.csv

--- a/src/crate/sphinx/csv.py
+++ b/src/crate/sphinx/csv.py
@@ -84,4 +84,4 @@ class CSVFilterDirective(CSVTable):
 
 
 def setup(sphinx):
-    sphinx.add_directive('csv-table', CSVFilterDirective)
+    sphinx.add_directive('csv-filter', CSVFilterDirective)

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,20 +1,28 @@
 [versions]
-Sphinx = 1.4.5
-Babel = 2.2.0
-Jinja2 = 2.8
-Pygments = 2.1.3
-alabaster = 0.7.7
-docutils = 0.12
-pytz = 2016.1
-six = 1.10.0
+Sphinx = 1.6.5
+Babel = 2.5.3
+Jinja2 = 2.10
+MarkupSafe = 1.0
+Pygments = 2.2.0
+alabaster = 0.7.10
+certifi = 2018.1.18
+chardet = 3.0.4
+docutils = 0.14
+idna = 2.6
+pytz = 2018.3
+requests = 2.18.4
+setuptools = 39.0.1
+six = 1.11.0
 snowballstemmer = 1.2.1
-zc.recipe.egg = 2.0.3
-wheel = 0.29.0
+urllib3 = 1.22
+wheel = 0.30.0
+zc.buildout = 2.11.2
+zc.recipe.egg = 2.0.5
 
 # Required by:
-# Jinja2==2.8
-MarkupSafe = 0.23
+# Sphinx==1.6.5
+imagesize = 1.0.0
 
 # Required by:
-# Sphinx==1.4.5
-imagesize = 0.7.0
+# Sphinx==1.6.5
+sphinxcontrib-websupport = 1.0.1


### PR DESCRIPTION
This was necessary with the Sphinx update to 1.6.5, because Sphinx now
logs a warning about already existing directive named `csv-table`.