### PR TITLE
Enhance filters and add missing doc.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,16 @@ If you're using other extensions, edit the existing list, or add this::
 Use
 ===
 
-This plugin adds the ``:exclude:`` option to the csv-table_ directive. This option takes a Python dict specifying the column index (starting at zero) and a regular expression. Rows are excluded if the columnar value matches the supplied regular expression.
+This plugin adds the following options to the csv-table_ directive:
+
+``:include:``
+    This option takes a Python dict specifying the column index (starting at zero) and a regular expression.
+    Rows are included if the columnar value matches the supplied regular expression.
+``:exclude:``
+    This option takes a Python dict specifying the column index (starting at zero) and a regular expression.
+    Rows are excluded if the columnar value matches the supplied regular expression.
+``:included_cols:``
+    This is a comma-separated list of column indexes to include in the output.
 
 Here's an example::
 

--- a/src/crate/sphinx/csv.py
+++ b/src/crate/sphinx/csv.py
@@ -6,14 +6,6 @@ import re
 from docutils.parsers.rst.directives.tables import CSVTable
 from docutils.utils import SystemMessagePropagation
 
-def include_dict(argument):
-    return ast.literal_eval(argument)
-
-
-def exclude_dict(argument):
-    return ast.literal_eval(argument)
-
-
 def non_negative_int(argument):
     """
     Converts the argument into an integer.
@@ -44,64 +36,62 @@ class CSVFilterDirective(CSVTable):
         and filter rows that contains a specified regex pattern
     """
 
-    CSVTable.option_spec['include'] = include_dict
-    CSVTable.option_spec['exclude'] = exclude_dict
+    CSVTable.option_spec['include'] = ast.literal_eval
+    CSVTable.option_spec['exclude'] = ast.literal_eval
     CSVTable.option_spec['included_cols'] = non_negative_int_list
 
     def parse_csv_data_into_rows(self, csv_data, dialect, source):
         rows, max_cols = super(CSVFilterDirective, self).parse_csv_data_into_rows(csv_data, dialect, source)
+        include_filters = exclude_filters = None
         if 'include' in self.options:
-            rows = self._apply_include_filter(rows, max_cols, self.options['include'])
+            include_filters = {k: re.compile(v) for k, v in self.options['include'].items()}
         if 'exclude' in self.options:
-            rows = self._apply_exclude_filter(rows, max_cols, self.options['exclude'])
+            exclude_filters = {k: re.compile(v) for k, v in self.options['exclude'].items()}
+        rows = self._apply_filters(rows, max_cols, include_filters, exclude_filters)
         if 'included_cols' in self.options:
             rows, max_cols = self._get_rows_with_included_cols(rows, self.options['included_cols'])
         return rows, max_cols
 
-    def _apply_include_filter(self, rows, max_cols, include_dict):
+
+    def _apply_filters(self, rows, max_cols, include_filters, exclude_filters):
         result = []
 
-        # append row that contains filter at column index
-        for row_idx, row in enumerate(rows):
-            include = False
-            if row_idx < self.options.get('header-rows', 0):
-                # Always include header rows, if any
-                include = True
-            else:
-                for col_idx, pattern in include_dict.items():
+        header_rows = self.options.get('header-rows', 0)
+        # Always include header rows, if any
+        result.extend(rows[:header_rows])
+
+        # Append row that does not contain filter at column index
+        for row in rows[header_rows:]:
+            # We generally include a row, ...
+            # ... unless include filters are defined, then we generally exclude them, ...
+            # ... unless at least one of the defined filters matches its cell ...
+            include = True
+            if include_filters:
+                include = False
+                for col_idx, pattern in include_filters.items():
                     # cell data value is located at hardcoded index pos. 3
                     # data type is always a string literal
                     if max_cols - 1 >= col_idx:
-                        print(pattern, row[col_idx][3][0], re.match(pattern, row[col_idx][3][0]))
-                        if re.match(pattern, row[col_idx][3][0]):
+                        if pattern.match(row[col_idx][3][0]):
                             include = True
                             break
+
+            # ... unless exclude filters are defined as well ...
+            # ... then we exclude a row if any of the defined exclude filters matches its cell.
+            if include and exclude_filters:
+                for col_idx, pattern in exclude_filters.items():
+                    # cell data value is located at hardcoded index pos. 3
+                    # data type is always a string literal
+                    if max_cols - 1 >= col_idx:
+                        if pattern.match(row[col_idx][3][0]):
+                            include = False
+                            break
+
             if include:
                 result.append(row)
 
         return result
 
-    def _apply_exclude_filter(self, rows, max_cols, exclude_dict):
-        result = []
-
-        # append row that does not contain filter at column index
-        for row_idx, row in enumerate(rows):
-            exclude = False
-            if row_idx < self.options.get('header-rows', 0):
-                # Always include header rows, if any
-                exclude = False
-            else:
-                for col_idx, pattern in exclude_dict.items():
-                    # cell data value is located at hardcoded index pos. 3
-                    # data type is always a string literal
-                    if max_cols - 1 >= col_idx:
-                        if re.match(pattern, row[col_idx][3][0]):
-                            exclude = True
-                            break
-            if not exclude:
-                result.append(row)
-
-        return result
 
     def _get_rows_with_included_cols(self, rows, included_cols_list):
         prepared_rows = []


### PR DESCRIPTION
Great plugin!
This PR addresses several issues.

## Summary of the changes / Why this is an improvement

**Add `:include:` filter option**
The exclude option is nice, but in some situations it is useful to filter out everything *except* several rows. Added an option to include rows based on a regex.
This filter is applied prior to the exclude filter so that both can be used intuitively (exclude takes precedence)

**Fix filter behavior when `:header-rows:` option is nonzero**
In the old behavior, if the `:header-rows:` option is used, then a filter could potentially exclude the header. This is unintuitive behavior.
This change forces headers to always be included if specified by  `:header-rows:`

**Add missing documentation for `:included_cols:` option**
Documentation was missing the `:included_cols:` option. This is very useful so I added it to the Readme.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
