### PR TITLE
Fix :include: filter to require all patterns to match. Fix stacktrace…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,11 +47,13 @@ This plugin adds the following options to the csv-table_ directive:
     This option takes a Python dict specifying the column index (starting at
     zero) and a regular expression. Rows are included if the columnar value
     matches the supplied regular expression.
+    If multiple filters are given, row is included if all columns match.
 
 ``:exclude:``
     This option takes a Python dict specifying the column index (starting at
     zero) and a regular expression. Rows are excluded if the columnar value
     matches the supplied regular expression.
+    If multiple filters are given, row is excluded if any columns match.
 
 If a row matches an ``:include:`` as well as an ``:exclude:`` filter, the row
 with be excluded.

--- a/README.rst
+++ b/README.rst
@@ -46,14 +46,12 @@ This plugin adds the following options to the csv-table_ directive:
 ``:include:``
     This option takes a Python dict specifying the column index (starting at
     zero) and a regular expression. Rows are included if the columnar value
-    matches the supplied regular expression.
-    If multiple filters are given, row is included if all columns match.
+    matches *all* supplied regular expressions.
 
 ``:exclude:``
     This option takes a Python dict specifying the column index (starting at
     zero) and a regular expression. Rows are excluded if the columnar value
-    matches the supplied regular expression.
-    If multiple filters are given, row is excluded if any columns match.
+    matches *any* supplied regular expressions.
 
 If a row matches an ``:include:`` as well as an ``:exclude:`` filter, the row
 with be excluded.

--- a/src/crate/sphinx/csv.py
+++ b/src/crate/sphinx/csv.py
@@ -70,19 +70,20 @@ class CSVFilterDirective(CSVTable):
         for row in rows[header_rows:]:
             # We generally include a row, ...
             include = True
-            for col_idx, pattern in include_filters.items():
-                # cell data value is located at hardcoded index pos. 3
-                # data type is always a string literal
-                if max_cols - 1 >= col_idx:
-                    # sanitize to empty string if cell is empty
-                    cell = row[col_idx][3][0] if row[col_idx][3] else ""
-                    if not pattern.match(cell):
-                        # ... unless any of the include filters do not match
-                        # it's cell ...
-                        include = False
-                        break
+            if include_filters:
+                for col_idx, pattern in include_filters.items():
+                    # cell data value is located at hardcoded index pos. 3
+                    # data type is always a string literal
+                    if max_cols - 1 >= col_idx:
+                        # sanitize to empty string if cell is empty
+                        cell = row[col_idx][3][0] if row[col_idx][3] else ""
+                        if not pattern.match(cell):
+                            # ... unless any of the include filters do not match
+                            # its cell ...
+                            include = False
+                            break
 
-            # ... unless exclude filters are defined (as well) ...
+            # ... or unless exclude filters are defined (as well) ...
             if include and exclude_filters:
                 for col_idx, pattern in exclude_filters.items():
                     # cell data value is located at hardcoded index pos. 3

--- a/src/crate/sphinx/csv.py
+++ b/src/crate/sphinx/csv.py
@@ -70,19 +70,17 @@ class CSVFilterDirective(CSVTable):
         for row in rows[header_rows:]:
             # We generally include a row, ...
             include = True
-            if include_filters:
-                # ... unless include filters are defined, then we generally
-                # exclude them, ...
-                include = False
-                for col_idx, pattern in include_filters.items():
-                    # cell data value is located at hardcoded index pos. 3
-                    # data type is always a string literal
-                    if max_cols - 1 >= col_idx:
-                        if pattern.match(row[col_idx][3][0]):
-                            # ... unless at least one of the defined filters
-                            # matches its cell ...
-                            include = True
-                            break
+            for col_idx, pattern in include_filters.items():
+                # cell data value is located at hardcoded index pos. 3
+                # data type is always a string literal
+                if max_cols - 1 >= col_idx:
+                    # sanitize to empty string if cell is empty
+                    cell = row[col_idx][3][0] if row[col_idx][3] else ""
+                    if not pattern.match(cell):
+                        # ... unless any of the include filters do not match
+                        # it's cell ...
+                        include = False
+                        break
 
             # ... unless exclude filters are defined (as well) ...
             if include and exclude_filters:
@@ -90,7 +88,9 @@ class CSVFilterDirective(CSVTable):
                     # cell data value is located at hardcoded index pos. 3
                     # data type is always a string literal
                     if max_cols - 1 >= col_idx:
-                        if pattern.match(row[col_idx][3][0]):
+                        # sanitize to empty string if cell is empty
+                        cell = row[col_idx][3][0] if row[col_idx][3] else ""
+                        if pattern.match(cell):
                             # ... then we exclude a row if any of the defined
                             # exclude filters matches its cell.
                             include = False

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -110,6 +110,12 @@ rows = [
         (0, 0, 0, ['Roland Mendel']),
         (0, 0, 0, ['Austria']),
         (0, 0, 0, ['NO']),
+    ],
+    [
+        (0, 0, 0, ['Wernher von Braun']),
+        (0, 0, 0, ['Hans Koenigsmann']),
+        (0, 0, 0, ['‎Germany']),
+        (0, 0, 0, []),  # Empty cell
     ]
 ]
 
@@ -122,13 +128,31 @@ def test_apply_none_filters():
 def test_apply_exclude_filters():
     exclude_filters = {3: re.compile(r'(?i)Y\w*', re.IGNORECASE)}
     result = directive._apply_filters(rows, 4, None, exclude_filters)
-    assert result == [rows[2]]
+    assert result == [rows[2], rows[3]]
+
+
+def test_apply_multi_exclude_filters():
+    exclude_filters = {
+        0: re.compile(r'Centro', re.IGNORECASE),
+        3: re.compile(r'NO', re.IGNORECASE)
+    }
+    result = directive._apply_filters(rows, 4, None, exclude_filters)
+    assert result == [rows[1], rows[3]]
 
 
 def test_apply_include_filters():
     include_filter = {3: re.compile(r'(?i)n\w*', re.IGNORECASE)}
     result = directive._apply_filters(rows, 4, include_filter, None)
     assert result == [rows[2]]
+
+
+def test_apply_multi_include_filters():
+    include_filter = {
+        2: re.compile(r'Ger', re.IGNORECASE),
+        3: re.compile(r'y', re.IGNORECASE)
+    }
+    result = directive._apply_filters(rows, 4, include_filter, None)
+    assert result == [rows[1]]
 
 
 def test_apply_include_exclude_filters():


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
* Fix logic of `:include:` filter to match original intent. Include filter should only include the row if _all_ filters match. Updated readme to describe behavior.
* Fix stacktrace if a column filter fetches an empty cell. Sanitizing to an empty string so that the user still has the option of matching against it with a regex.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
