### PR TITLE
Declare extension as safe for parallel reading and writing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Unreleased
 ==========
 
 
+2023/04/18 0.4.1
+================
+
 - Declare extension as safe for parallel reading and writing
 
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Unreleased
 ==========
 
 
+- Declare extension as safe for parallel reading and writing
+
+
 2022/12/12 0.4.0
 ================
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ def read(path):
 
 setup(
     name='sphinx-csv-filter',
-    version='0.4.0',
+    version='0.4.1',
     url='https://github.com/crate/sphinx_csv_filter',
     author='Crate.IO GmbH',
     author_email='office@crate.io',

--- a/src/crate/sphinx/csv.py
+++ b/src/crate/sphinx/csv.py
@@ -117,3 +117,7 @@ class CSVFilterDirective(CSVTable):
 
 def setup(sphinx):
     sphinx.add_directive('csv-filter', CSVFilterDirective)
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
Hi.

This patch follows the suggestion by @rmartin16 on behalf of GH-46, to adjust the `setup()` function slightly in order to signal that this Sphinx extension is safe for parallel reading and writing, following, for example, https://github.com/sphinx-contrib/autoprogram/pull/18.

More information about that is available at https://www.sphinx-doc.org/en/master/extdev/index.html#extension-metadata.

With kind regards,
Andreas.
