### PR TITLE
Chore: Update default branch name

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
   # Allow job to be triggered manually.
   workflow_dispatch:

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -44,7 +44,7 @@ To create a new release, you must:
 
 - Commit your changes with a message like "prepare release x.y.z"
 
-- Push to ``origin/master``
+- Push to ``origin/main``
 
 - Create a tag by running ``./devtools/create_tag.sh``
 

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Sphinx CSV filter
     :target: https://github.com/crate/sphinx_csv_filter/actions/workflows/tests.yml
     :alt: CI outcome
 
-.. image:: https://codecov.io/gh/crate/sphinx_csv_filter/branch/master/graph/badge.svg
+.. image:: https://codecov.io/gh/crate/sphinx_csv_filter/branch/main/graph/badge.svg
     :target: https://app.codecov.io/gh/crate/sphinx_csv_filter
     :alt: Test suite code coverage
 

--- a/devtools/create_tag.sh
+++ b/devtools/create_tag.sh
@@ -35,7 +35,7 @@ git fetch origin > /dev/null
 BRANCH=$(git branch | grep "^\*" | cut -d " " -f 2)
 echo "Current branch is $BRANCH."
 
-# check if master == origin/master
+# check if main == origin/main
 LOCAL_COMMIT=$(git show --format="%H" "$BRANCH")
 ORIGIN_COMMIT=$(git show --format="%H" "origin/$BRANCH")
 


### PR DESCRIPTION
I've changed the default branch name to `main`. This patch accompanies it.